### PR TITLE
Feature/prefix ambiguous type method for package repo and upstream

### DIFF
--- a/lib/metarepo/command/repo_create.rb
+++ b/lib/metarepo/command/repo_create.rb
@@ -2,13 +2,13 @@
 # Author: adam@opscode.com
 #
 # Copyright 2012, Opscode, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,29 +24,27 @@ require 'mixlib/cli'
 
 class Metarepo
   class Command
-		class RepoCreate < Metarepo::Command
+    class RepoCreate < Metarepo::Command
 
-			option :name,
-				:short => "-n NAME",
-				:long => "--name NAME",
-				:description => "The repo name",
-				:required => true
+      option :name,
+      :short => "-n NAME",
+      :long => "--name NAME",
+      :description => "The repo name",
+      :required => true
 
-			option :type,
-				:short => "-t TYPE",
-				:long => "--type TYPE",
-				:description => "The repo type (yum, apt, dir)",
-				:required => true
+      option :type,
+      :short => "-t TYPE",
+      :long => "--type TYPE",
+      :description => "The repo type (yum, apt, dir)",
+      :required => true
 
-			def run
-				@rest["/repo/#{config[:name]}"].put(
-					Yajl::Encoder.encode({ "name" => config[:name], "type" => config[:type] }),
-					{ :content_type => "application/json" }
-				)
-				exit 0
-			end
-		end
+      def run
+        @rest["/repo/#{config[:name]}"].put(
+                                            Yajl::Encoder.encode({ "name" => config[:name], "type" => config[:type] }),
+                                            { :content_type => "application/json" }
+                                            )
+        exit 0
+      end
+    end
   end
 end
-
-

--- a/lib/metarepo/command/repo_create.rb
+++ b/lib/metarepo/command/repo_create.rb
@@ -32,15 +32,15 @@ class Metarepo
       :description => "The repo name",
       :required => true
 
-      option :type,
-      :short => "-t TYPE",
-      :long => "--type TYPE",
+      option :repo_type,
+      :short => "-t REPO_TYPE",
+      :long => "--type REPO_TYPE",
       :description => "The repo type (yum, apt, dir)",
       :required => true
 
       def run
         @rest["/repo/#{config[:name]}"].put(
-                                            Yajl::Encoder.encode({ "name" => config[:name], "type" => config[:type] }),
+                                            Yajl::Encoder.encode({ "name" => config[:name], "repo_type" => config[:repo_type] }),
                                             { :content_type => "application/json" }
                                             )
         exit 0

--- a/lib/metarepo/command/repo_list.rb
+++ b/lib/metarepo/command/repo_list.rb
@@ -2,13 +2,13 @@
 # Author: adam@opscode.com
 #
 # Copyright 2012, Opscode, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,16 +24,13 @@ require 'mixlib/cli'
 
 class Metarepo
   class Command
-		class RepoList < Metarepo::Command
-			def run
-				response = @rest["/repo"].get
-				data = Yajl::Parser.parse(response.body)
-				puts Yajl::Encoder.encode(data, :pretty => true, :indent => "  ")
-				exit 0
-			end
-		end
+    class RepoList < Metarepo::Command
+      def run
+        response = @rest["/repo"].get
+        data = Yajl::Parser.parse(response.body)
+        puts Yajl::Encoder.encode(data, :pretty => true, :indent => "  ")
+        exit 0
+      end
+    end
   end
 end
-
-
-

--- a/lib/metarepo/command/repo_packages.rb
+++ b/lib/metarepo/command/repo_packages.rb
@@ -2,13 +2,13 @@
 # Author: adam@opscode.com
 #
 # Copyright 2012, Opscode, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,24 +24,19 @@ require 'mixlib/cli'
 
 class Metarepo
   class Command
-		class RepoPackages < Metarepo::Command
-			option :name,
-				:short => "-n NAME",
-				:long => "--name NAME",
-				:description => "The repo name",
-				:required => true
+    class RepoPackages < Metarepo::Command
+      option :name,
+      :short => "-n NAME",
+      :long => "--name NAME",
+      :description => "The repo name",
+      :required => true
 
-			def run
-				response = @rest["/repo/#{config[:name]}/packages"].get
-				data = Yajl::Parser.parse(response.body)
-				puts Yajl::Encoder.encode(data, :pretty => true, :indent => "  ")
-				exit 0
-			end
-		end
+      def run
+        response = @rest["/repo/#{config[:name]}/packages"].get
+        data = Yajl::Parser.parse(response.body)
+        puts Yajl::Encoder.encode(data, :pretty => true, :indent => "  ")
+        exit 0
+      end
+    end
   end
 end
-
-
-
-
-

--- a/lib/metarepo/command/repo_show.rb
+++ b/lib/metarepo/command/repo_show.rb
@@ -2,13 +2,13 @@
 # Author: adam@opscode.com
 #
 # Copyright 2012, Opscode, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,23 +24,19 @@ require 'mixlib/cli'
 
 class Metarepo
   class Command
-		class RepoShow < Metarepo::Command
-			option :name,
-				:short => "-n NAME",
-				:long => "--name NAME",
-				:description => "The repo name",
-				:required => true
+    class RepoShow < Metarepo::Command
+      option :name,
+      :short => "-n NAME",
+      :long => "--name NAME",
+      :description => "The repo name",
+      :required => true
 
-			def run
-				response = @rest["/repo/#{config[:name]}"].get
-				data = Yajl::Parser.parse(response.body)
-				puts Yajl::Encoder.encode(data, :pretty => true, :indent => "  ")
-				exit 0
-			end
-		end
+      def run
+        response = @rest["/repo/#{config[:name]}"].get
+        data = Yajl::Parser.parse(response.body)
+        puts Yajl::Encoder.encode(data, :pretty => true, :indent => "  ")
+        exit 0
+      end
+    end
   end
 end
-
-
-
-

--- a/lib/metarepo/command/repo_sync.rb
+++ b/lib/metarepo/command/repo_sync.rb
@@ -32,9 +32,9 @@ class Metarepo
       :description => "The repo name",
       :required => true
 
-      option :type,
-      :short => "-t TYPE",
-      :long => "--type TYPE",
+      option :repo_type,
+      :short => "-t REPO_TYPE",
+      :long => "--type REPO_TYPE",
       :description => "The type of thing to sync to (upstream or repo)",
       :required => true
 
@@ -46,7 +46,7 @@ class Metarepo
 
       def run
         response = @rest["/repo/#{config[:name]}/packages"].put(
-                                                                Yajl::Encoder.encode({ "sync" => { "type" => config[:type], "name" => config[:sync_to] }}),
+                                                                Yajl::Encoder.encode({ "sync" => { "repo_type" => config[:repo_type], "name" => config[:sync_to] }}),
                                                                 { :content_type => "application/json" }
                                                                 )
         data = Yajl::Parser.parse(response.body)

--- a/lib/metarepo/command/repo_sync.rb
+++ b/lib/metarepo/command/repo_sync.rb
@@ -2,13 +2,13 @@
 # Author: adam@opscode.com
 #
 # Copyright 2012, Opscode, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,37 +24,35 @@ require 'mixlib/cli'
 
 class Metarepo
   class Command
-		class RepoSync < Metarepo::Command
+    class RepoSync < Metarepo::Command
 
-			option :name,
-				:short => "-n NAME",
-				:long => "--name NAME",
-				:description => "The repo name",
-				:required => true
+      option :name,
+      :short => "-n NAME",
+      :long => "--name NAME",
+      :description => "The repo name",
+      :required => true
 
-			option :type,
-				:short => "-t TYPE",
-				:long => "--type TYPE",
-				:description => "The type of thing to sync to (upstream or repo)",
-				:required => true
+      option :type,
+      :short => "-t TYPE",
+      :long => "--type TYPE",
+      :description => "The type of thing to sync to (upstream or repo)",
+      :required => true
 
-			option :sync_to,
-				:short => "-s SYNC_TO",
-				:long => "--sync SYNC_TO",
-				:description => "The specific thing to sync to",
-				:required => true
+      option :sync_to,
+      :short => "-s SYNC_TO",
+      :long => "--sync SYNC_TO",
+      :description => "The specific thing to sync to",
+      :required => true
 
-			def run
-				response = @rest["/repo/#{config[:name]}/packages"].put(
-					Yajl::Encoder.encode({ "sync" => { "type" => config[:type], "name" => config[:sync_to] }}),
-					{ :content_type => "application/json" }
-				)
-				data = Yajl::Parser.parse(response.body)
-				puts Yajl::Encoder.encode(data, :pretty => true, :indent => "  ")
-				loop_on_job(data)
-			end
-		end
+      def run
+        response = @rest["/repo/#{config[:name]}/packages"].put(
+                                                                Yajl::Encoder.encode({ "sync" => { "type" => config[:type], "name" => config[:sync_to] }}),
+                                                                { :content_type => "application/json" }
+                                                                )
+        data = Yajl::Parser.parse(response.body)
+        puts Yajl::Encoder.encode(data, :pretty => true, :indent => "  ")
+        loop_on_job(data)
+      end
+    end
   end
 end
-
-

--- a/lib/metarepo/command/upstream_create.rb
+++ b/lib/metarepo/command/upstream_create.rb
@@ -32,9 +32,9 @@ class Metarepo
       :description => "The upstream name",
       :required => true
 
-      option :type,
-      :short => "-t TYPE",
-      :long => "--type TYPE",
+      option :upstream_type,
+      :short => "-t UPSTREAM_TYPE",
+      :long => "--type UPSTREAM_TYPE",
       :description => "The upstream type (yum, apt, dir)",
       :required => true
 
@@ -47,7 +47,7 @@ class Metarepo
       # upstream create
       def run
         response = @rest["/upstream/#{config[:name]}"].put(
-                                                           Yajl::Encoder.encode({ "name" => config[:name], "type" => config[:type], "path" => config[:path] }),
+                                                           Yajl::Encoder.encode({ "name" => config[:name], "upstream_type" => config[:upstream_type], "path" => config[:path] }),
                                                            { :content_type => "application/json" }
                                                            )
         data = Yajl::Parser.parse(response.body)

--- a/lib/metarepo/command/upstream_create.rb
+++ b/lib/metarepo/command/upstream_create.rb
@@ -2,13 +2,13 @@
 # Author: adam@opscode.com
 #
 # Copyright 2012, Opscode, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,37 +24,36 @@ require 'mixlib/cli'
 
 class Metarepo
   class Command
-		class UpstreamCreate < Metarepo::Command
+    class UpstreamCreate < Metarepo::Command
 
-			option :name,
-				:short => "-n NAME",
-				:long => "--name NAME",
-				:description => "The upstream name",
-				:required => true
+      option :name,
+      :short => "-n NAME",
+      :long => "--name NAME",
+      :description => "The upstream name",
+      :required => true
 
-			option :type,
-				:short => "-t TYPE",
-				:long => "--type TYPE",
-				:description => "The upstream type (yum, apt, dir)",
-				:required => true
+      option :type,
+      :short => "-t TYPE",
+      :long => "--type TYPE",
+      :description => "The upstream type (yum, apt, dir)",
+      :required => true
 
-			option :path,
-				:short => "-p PATH",
-				:long => "--path PATH",
-				:description => "The upstream path",
-				:required => true
+      option :path,
+      :short => "-p PATH",
+      :long => "--path PATH",
+      :description => "The upstream path",
+      :required => true
 
-			# upstream create 
-			def run
-				response = @rest["/upstream/#{config[:name]}"].put(
-					Yajl::Encoder.encode({ "name" => config[:name], "type" => config[:type], "path" => config[:path] }),
-					{ :content_type => "application/json" }
-				)
-				data = Yajl::Parser.parse(response.body)
-				puts Yajl::Encoder.encode(data, :pretty => true, :indent => "  ")
-				loop_on_job(data)
-			end
-		end
+      # upstream create
+      def run
+        response = @rest["/upstream/#{config[:name]}"].put(
+                                                           Yajl::Encoder.encode({ "name" => config[:name], "type" => config[:type], "path" => config[:path] }),
+                                                           { :content_type => "application/json" }
+                                                           )
+        data = Yajl::Parser.parse(response.body)
+        puts Yajl::Encoder.encode(data, :pretty => true, :indent => "  ")
+        loop_on_job(data)
+      end
+    end
   end
 end
-

--- a/lib/metarepo/package.rb
+++ b/lib/metarepo/package.rb
@@ -2,13 +2,13 @@
 # Author: adam@opscode.com
 #
 # Copyright 2012, Opscode, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -72,29 +72,29 @@ class Metarepo
       Metarepo.command_per_line('dpkg-deb --show --showformat \'name: ${Package}\nversion: ${Version}\narch: ${Architecture}\nmaintainer: ${Maintainer}\ndescription: ${Description}\nurl: ${Homepage}\n\' ' + file) do |item|
         next if item =~ /^ / # Skip extraneous lines from dpkg
         case item
-				when /^(.+?): (.+)$/
-					accessor = $1
-					value = $2
-				when /^(.+?):/
-					accessor = $1
-					value = "nil"
-				end
-				Metarepo::Log.debug("#{accessor} #{value}")
+        when /^(.+?): (.+)$/
+          accessor = $1
+          value = $2
+        when /^(.+?):/
+          accessor = $1
+          value = "nil"
+        end
+        Metarepo::Log.debug("#{accessor} #{value}")
 
         if accessor == 'version'
           if value =~ /^(.+)-(.+)$/
-						version = $1
-						iteration = $2
-					else
-						version = value
-						iteration = 0
-					end
-					p.send("version=".to_sym, version)
-					p.send("iteration=".to_sym, iteration)
-				elsif accessor != "" && !accessor.nil?
+            version = $1
+            iteration = $2
+          else
+            version = value
+            iteration = 0
+          end
+          p.send("version=".to_sym, version)
+          p.send("iteration=".to_sym, iteration)
+        elsif accessor != "" && !accessor.nil?
           p.send("#{accessor}=".to_sym, value)
-				else
-					Metarepo::Log.debug("Blank accessor!")
+        else
+          Metarepo::Log.debug("Blank accessor!")
         end
       end
       p
@@ -105,7 +105,7 @@ class Metarepo
       hashfunc = Digest::SHA256.new
       File.open(file, "rb") do |io|
         while (!io.eof)
-          hashfunc.update(io.readpartial(1024)) 
+          hashfunc.update(io.readpartial(1024))
         end
       end
       Metarepo::Log.debug("#{file} shasum #{hashfunc.hexdigest}")
@@ -117,7 +117,7 @@ class Metarepo
       hashfunc = Digest::SHA1.new
       File.open(file, "rb") do |io|
         while (!io.eof)
-          hashfunc.update(io.readpartial(1024)) 
+          hashfunc.update(io.readpartial(1024))
         end
       end
       Metarepo::Log.debug("#{file} shasum #{hashfunc.hexdigest}")
@@ -129,7 +129,7 @@ class Metarepo
       hashfunc = Digest::MD5.new
       File.open(file, "rb") do |io|
         while (!io.eof)
-          hashfunc.update(io.readpartial(1024)) 
+          hashfunc.update(io.readpartial(1024))
         end
       end
       Metarepo::Log.debug("#{file} shasum #{hashfunc.hexdigest}")
@@ -145,4 +145,3 @@ class Metarepo
 
   end
 end
-

--- a/lib/metarepo/package.rb
+++ b/lib/metarepo/package.rb
@@ -43,7 +43,7 @@ class Metarepo
       return p if !p.nil?
       p = Metarepo::Package.new
       p.shasum = shasum
-      p.type = "rpm"
+      p.package_type = "rpm"
       p.path = file
       p.filename = File.basename(file)
       Metarepo::Log.debug("Extracting package data from #{file}")
@@ -65,7 +65,7 @@ class Metarepo
       return p if !p.nil?
       p = Metarepo::Package.new
       p.shasum = shasum
-      p.type = "deb"
+      p.package_type = "deb"
       p.path = file
       p.filename = File.basename(file)
       Metarepo::Log.debug("Extracting package data from #{file}")
@@ -139,8 +139,8 @@ class Metarepo
     def validate
       super
       validates_unique :shasum
-      validates_presence [ :name, :version, :iteration, :arch, :maintainer, :url, :description, :path, :type, :filename ]
-      errors.add(:type, "must be deb or rpm") unless [ "deb", "rpm" ].include?(type)
+      validates_presence [ :name, :version, :iteration, :arch, :maintainer, :url, :description, :path, :package_type, :filename ]
+      errors.add(:package_type, "must be deb or rpm") unless [ "deb", "rpm" ].include?(package_type)
     end
 
   end

--- a/lib/metarepo/repo.rb
+++ b/lib/metarepo/repo.rb
@@ -2,13 +2,13 @@
 # Author: adam@opscode.com
 #
 # Copyright 2012, Opscode, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,12 +40,12 @@ class Metarepo
         Dir[File.join(path, "*.deb")]
       when "dir"
         [
-          Dir[File.join(path, "*.rpm")],
-          Dir[File.join(path, "*.deb")]
+         Dir[File.join(path, "*.rpm")],
+         Dir[File.join(path, "*.deb")]
         ].flatten
       end
     end
-  
+
     def repo_path
       rpath = @repo_dir.nil? ? Metarepo::Config.repo_path : @repo_dir
       File.expand_path(File.join(rpath, name))
@@ -69,13 +69,13 @@ class Metarepo
         Metarepo::Log.info("Building hard link for missing package #{package.name} in repo")
         File.link(pool.pool_file_for(package), repo_file_for(package))
       end
-      add_package(package) unless packages.detect { |o| o.shasum == package.shasum } 
+      add_package(package) unless packages.detect { |o| o.shasum == package.shasum }
     end
 
     def unlink_package(package, pool=nil)
       Metarepo::Log.info("Unlinking #{package.name} from repo #{name}")
       File.unlink(repo_file_for(package)) if File.exists?(repo_file_for(package))
-      remove_package(package) 
+      remove_package(package)
     end
 
     def sync_packages(upstream_packages, pool=nil)
@@ -118,11 +118,11 @@ class Metarepo
 
         File.open(File.join(arch_dist_path, "Release"), "w") do |file|
           file.print <<-EOH
-Archive: #{name} 
+Archive: #{name}
 Component: main
-Origin: metarepo 
-Label: metarepo 
-Architecture: #{arch} 
+Origin: metarepo
+Label: metarepo
+Architecture: #{arch}
           EOH
         end
         package_files << File.open(File.join(arch_dist_path, "Packages"), "w")
@@ -153,7 +153,7 @@ Architecture: #{arch}
           package_files.each do |pfile|
             Metarepo::Log.info("Writing #{deb_file} to #{pfile.path}")
             if pfile.path =~ /binary-#{package_arch}/ || package_arch == "all"
-              pfile.puts package_data 
+              pfile.puts package_data
               pfile.print "\n"
             end
           end
@@ -166,17 +166,17 @@ Architecture: #{arch}
       File.open(File.join(repo_path, "dists", "main", "Release"), "w") do |release_file|
         release_file.puts <<-EOH
 Origin: metarepo
-Label: metarepo 
-Codename: main 
+Label: metarepo
+Codename: main
 Components: main
-Architectures: #{archs.join(" ")} 
+Architectures: #{archs.join(" ")}
 EOH
         md5string = "MD5Sum:\n"
         sha1string = "SHA1:\n"
         sha256string = "SHA256:\n"
         files_to_include_in_release.each do |file|
           file =~ /(binary-.+)$/
-          filename = $1 
+          filename = $1
           size = File.stat(file).size
           md5sum = Metarepo::Package.get_md5sum(file)
           sha1sum = Metarepo::Package.get_shasum1(file)
@@ -204,11 +204,10 @@ EOH
       case type
       when "yum"
         update_index_yum
-			when "apt"
+      when "apt"
         update_index_apt
       end
     end
 
   end
 end
-

--- a/lib/metarepo/repo.rb
+++ b/lib/metarepo/repo.rb
@@ -28,12 +28,12 @@ class Metarepo
     def validate
       super
       validates_unique :name
-      validates_presence [ :type ]
-      errors.add(:type, "must be yum, apt or dir") unless [ "yum", "apt", "dir" ].include?(type)
+      validates_presence [ :repo_type ]
+      errors.add(:repo_type, "must be yum, apt or dir") unless [ "yum", "apt", "dir" ].include?(repo_type)
     end
 
     def list_packages
-      case type
+      case repo_type
       when "yum"
         Dir[File.join(path, "*.rpm")]
       when "apt"
@@ -52,7 +52,7 @@ class Metarepo
     end
 
     def repo_file_for(package)
-      case type
+      case repo_type
       when "apt"
         Metarepo.create_directory(File.join(repo_path, "pool"))
         File.expand_path(File.join(repo_path, "pool", package.filename))
@@ -201,7 +201,7 @@ EOH
 
     def update_index
       Metarepo::Log.info("Creating package index")
-      case type
+      case repo_type
       when "yum"
         update_index_yum
       when "apt"

--- a/lib/metarepo/rest_api.rb
+++ b/lib/metarepo/rest_api.rb
@@ -2,13 +2,13 @@
 # Author: adam@opscode.com
 #
 # Copyright 2012, Opscode, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,11 +28,11 @@ require 'metarepo/job/repo_packages'
 require 'resque'
 
 class Metarepo
-	class RestAPI < Sinatra::Base
+  class RestAPI < Sinatra::Base
 
-		def serialize(data)
-			Yajl::Encoder.encode(data)
-		end
+    def serialize(data)
+      Yajl::Encoder.encode(data)
+    end
 
     def package_serialize(p)
       {
@@ -42,7 +42,7 @@ class Metarepo
         "path" => p.path,
         "filename" => p.filename,
         "version" => p.version,
-				"iteration" => p.iteration,
+        "iteration" => p.iteration,
         "arch" => p.arch,
         "maintainer" => p.maintainer,
         "description" => p.description,
@@ -50,57 +50,57 @@ class Metarepo
       }
     end
 
-		get "/upstream" do
-			content_type :json
-			response_data = {}
-			Metarepo::Upstream.each do |upstream|
-				response_data[upstream.name] = url("/upstream/#{upstream.name}")
-			end
-			serialize(response_data)
-		end
+    get "/upstream" do
+      content_type :json
+      response_data = {}
+      Metarepo::Upstream.each do |upstream|
+        response_data[upstream.name] = url("/upstream/#{upstream.name}")
+      end
+      serialize(response_data)
+    end
 
-		post "/upstream" do
-			content_type :json
-			request.body.rewind
-			upstream_data = Yajl::Parser.parse(request.body.read)
-			upstream = Metarepo::Upstream.new
-			upstream.name = upstream_data["name"]
-			upstream.path = upstream_data["path"]
-			upstream.type = upstream_data["type"]
-			begin
-				upstream.save
-			rescue Sequel::ValidationFailed => e
-				if e.message == "name is already taken"
-					status 409
-					return serialize({ "error" => e.message })
-				else
-					status 400
-					return serialize({ "error" => e.message })
-				end
-			end
+    post "/upstream" do
+      content_type :json
+      request.body.rewind
+      upstream_data = Yajl::Parser.parse(request.body.read)
+      upstream = Metarepo::Upstream.new
+      upstream.name = upstream_data["name"]
+      upstream.path = upstream_data["path"]
+      upstream.type = upstream_data["type"]
+      begin
+        upstream.save
+      rescue Sequel::ValidationFailed => e
+        if e.message == "name is already taken"
+          status 409
+          return serialize({ "error" => e.message })
+        else
+          status 400
+          return serialize({ "error" => e.message })
+        end
+      end
       status 201
       meta = Metarepo::Job::UpstreamSyncPackages.enqueue(upstream.id)
       serialize({ :enqueued_at => meta.enqueued_at, :job_id => meta.meta_id, :job_class => meta.job_class })
-		end
+    end
 
     get "/upstream/:name" do
       content_type :json
       upstream = Metarepo::Upstream[:name => params[:name]]
       serialize(
-        {
-          "name" => upstream[:name],
-          "type" => upstream[:type],
-          "path" => upstream[:path],
-          "created_at" => upstream[:created_at],
-          "updated_at" => upstream[:updated_at]
-        }
-      )
+                {
+                  "name" => upstream[:name],
+                  "type" => upstream[:type],
+                  "path" => upstream[:path],
+                  "created_at" => upstream[:created_at],
+                  "updated_at" => upstream[:updated_at]
+                }
+                )
     end
 
-		put "/upstream/:name" do
-			content_type :json
-			request.body.rewind
-			upstream_data = Yajl::Parser.parse(request.body.read)
+    put "/upstream/:name" do
+      content_type :json
+      request.body.rewind
+      upstream_data = Yajl::Parser.parse(request.body.read)
       upstream = Metarepo::Upstream[:name => upstream_data["name"]]
       if upstream
         status 202
@@ -114,27 +114,27 @@ class Metarepo
 
       begin
         upstream.save
-			rescue Sequel::ValidationFailed => e
+      rescue Sequel::ValidationFailed => e
         status 400
         return serialize({ "error" => e.message })
-			end
+      end
 
       meta = Metarepo::Job::UpstreamSyncPackages.enqueue(upstream.id)
       serialize({ :enqueued_at => meta.enqueued_at, :job_id => meta.meta_id, :job_class => meta.job_class })
-		end
+    end
 
     get "/upstream/:name/packages" do
-			content_type :json
+      content_type :json
       upstream = Metarepo::Upstream[:name => params["name"]]
       response = {}
       upstream.packages_dataset.all do |p|
-        response[p.shasum] = package_serialize(p) 
+        response[p.shasum] = package_serialize(p)
       end
       serialize(response)
     end
 
     get "/package" do
-			content_type :json
+      content_type :json
       response = {}
       Metarepo::Package.dataset.select(:shasum).each do |package|
         response[package.shasum] = url("/package/#{package.shasum}")
@@ -143,14 +143,14 @@ class Metarepo
     end
 
     get "/package/:shasum" do
-			content_type :json
+      content_type :json
       response = {}
       package = Metarepo::Package[:shasum => params[:shasum]]
       serialize(package_serialize(package))
     end
 
     get "/repo" do
-			content_type :json
+      content_type :json
       response = {}
       Metarepo::Repo.dataset.select(:name).each do |repo|
         response[repo.name] = url("/repo/#{repo.name}")
@@ -158,44 +158,44 @@ class Metarepo
       serialize(response)
     end
 
-		post "/repo" do
-			content_type :json
-			request.body.rewind
-			repo_data = Yajl::Parser.parse(request.body.read)
-			repo = Metarepo::Repo.new
-			repo.name = repo_data["name"]
-			repo.type = repo_data["type"]
-			begin
-				repo.save
-			rescue Sequel::ValidationFailed => e
-				if e.message == "name is already taken"
-					status 409
-					return serialize({ "error" => e.message })
-				else
-					status 400
-					return serialize({ "error" => e.message })
-				end
-			end
+    post "/repo" do
+      content_type :json
+      request.body.rewind
+      repo_data = Yajl::Parser.parse(request.body.read)
+      repo = Metarepo::Repo.new
+      repo.name = repo_data["name"]
+      repo.type = repo_data["type"]
+      begin
+        repo.save
+      rescue Sequel::ValidationFailed => e
+        if e.message == "name is already taken"
+          status 409
+          return serialize({ "error" => e.message })
+        else
+          status 400
+          return serialize({ "error" => e.message })
+        end
+      end
       status 201
       serialize({ repo.name => url("/repo/#{repo.name}") })
-		end
+    end
 
     get "/repo/:name" do
-			content_type :json
+      content_type :json
       response = {}
       repo = Metarepo::Repo[:name => params[:name]]
       serialize({
-        "name" => repo.name,
-        "type" => repo.type,
-        "created_at" => repo.created_at,
-        "updated_at" => repo.updated_at
-      })
+                  "name" => repo.name,
+                  "type" => repo.type,
+                  "created_at" => repo.created_at,
+                  "updated_at" => repo.updated_at
+                })
     end
 
-		put "/repo/:name" do
-			content_type :json
-			request.body.rewind
-			repo_data = Yajl::Parser.parse(request.body.read)
+    put "/repo/:name" do
+      content_type :json
+      request.body.rewind
+      repo_data = Yajl::Parser.parse(request.body.read)
       repo = Metarepo::Repo[:name => repo_data["name"]]
       if repo
         status 202
@@ -203,29 +203,29 @@ class Metarepo
         status 201
         repo = Metarepo::Repo.new
       end
-			repo.name = repo_data["name"]
-			repo.type = repo_data["type"]
+      repo.name = repo_data["name"]
+      repo.type = repo_data["type"]
 
-			begin
-				repo.save
-			rescue Sequel::ValidationFailed => e
+      begin
+        repo.save
+      rescue Sequel::ValidationFailed => e
         status 400
         return serialize({ "error" => e.message })
-			end
+      end
       serialize(
-        {
-          "name" => repo[:name],
-          "type" => repo[:type],
-          "created_at" => repo[:created_at],
-          "updated_at" => repo[:updated_at]
-        }
-      )
-		end
+                {
+                  "name" => repo[:name],
+                  "type" => repo[:type],
+                  "created_at" => repo[:created_at],
+                  "updated_at" => repo[:updated_at]
+                }
+                )
+    end
 
     put "/repo/:name/packages" do
-			content_type :json
-			request.body.rewind
-			package_data = Yajl::Parser.parse(request.body.read)
+      content_type :json
+      request.body.rewind
+      package_data = Yajl::Parser.parse(request.body.read)
       repo = Metarepo::Repo[:name => params[:name]]
       if package_data.has_key?("sync")
         meta = Metarepo::Job::RepoSyncPackages.enqueue(repo.name, package_data["sync"]["type"], package_data["sync"]["name"])
@@ -237,18 +237,17 @@ class Metarepo
     end
 
     get "/job/:job_class/:job_id" do
-			content_type :json
+      content_type :json
       meta = Resque.constantize(params["job_class"]).get_meta(params["job_id"])
       serialize({
-        :job_id => meta.meta_id,
-        :job_class => meta.job_class,
-        :enqueued_at => meta.enqueued_at,
-        :started_at => meta.started_at,
-        :succeeded => meta.succeeded?,
-        :finished_at => meta.finished_at
-      })
+                  :job_id => meta.meta_id,
+                  :job_class => meta.job_class,
+                  :enqueued_at => meta.enqueued_at,
+                  :started_at => meta.started_at,
+                  :succeeded => meta.succeeded?,
+                  :finished_at => meta.finished_at
+                })
     end
 
-	end
+  end
 end
-

--- a/lib/metarepo/rest_api.rb
+++ b/lib/metarepo/rest_api.rb
@@ -37,7 +37,7 @@ class Metarepo
     def package_serialize(p)
       {
         "name" => p.name,
-        "type" => p.type,
+        "package_type" => p.package_type,
         "shasum" => p.shasum,
         "path" => p.path,
         "filename" => p.filename,
@@ -66,7 +66,7 @@ class Metarepo
       upstream = Metarepo::Upstream.new
       upstream.name = upstream_data["name"]
       upstream.path = upstream_data["path"]
-      upstream.type = upstream_data["type"]
+      upstream.upstream_type = upstream_data["upstream_type"]
       begin
         upstream.save
       rescue Sequel::ValidationFailed => e
@@ -89,7 +89,7 @@ class Metarepo
       serialize(
                 {
                   "name" => upstream[:name],
-                  "type" => upstream[:type],
+                  "upstream_type" => upstream[:upstream_type],
                   "path" => upstream[:path],
                   "created_at" => upstream[:created_at],
                   "updated_at" => upstream[:updated_at]
@@ -110,7 +110,7 @@ class Metarepo
       end
       upstream.name = upstream_data["name"]
       upstream.path = upstream_data["path"]
-      upstream.type = upstream_data["type"]
+      upstream.upstream_type = upstream_data["upstream_type"]
 
       begin
         upstream.save
@@ -164,7 +164,7 @@ class Metarepo
       repo_data = Yajl::Parser.parse(request.body.read)
       repo = Metarepo::Repo.new
       repo.name = repo_data["name"]
-      repo.type = repo_data["type"]
+      repo.repo_type = repo_data["repo_type"]
       begin
         repo.save
       rescue Sequel::ValidationFailed => e
@@ -186,7 +186,7 @@ class Metarepo
       repo = Metarepo::Repo[:name => params[:name]]
       serialize({
                   "name" => repo.name,
-                  "type" => repo.type,
+                  "repo_type" => repo.repo_type,
                   "created_at" => repo.created_at,
                   "updated_at" => repo.updated_at
                 })
@@ -204,7 +204,7 @@ class Metarepo
         repo = Metarepo::Repo.new
       end
       repo.name = repo_data["name"]
-      repo.type = repo_data["type"]
+      repo.repo_type = repo_data["repo_type"]
 
       begin
         repo.save
@@ -215,7 +215,7 @@ class Metarepo
       serialize(
                 {
                   "name" => repo[:name],
-                  "type" => repo[:type],
+                  "repo_type" => repo[:repo_type],
                   "created_at" => repo[:created_at],
                   "updated_at" => repo[:updated_at]
                 }

--- a/lib/metarepo/upstream.rb
+++ b/lib/metarepo/upstream.rb
@@ -28,8 +28,8 @@ class Metarepo
     def validate
       super
       validates_unique :name
-      validates_presence [ :path, :type ]
-      errors.add(:type, "must be yum, apt or dir") unless [ "yum", "apt", "dir" ].include?(type)
+      validates_presence [ :path, :upstream_type ]
+      errors.add(:upstream_type, "must be yum, apt or dir") unless [ "yum", "apt", "dir" ].include?(upstream_type)
     end
 
     def list_packages
@@ -38,7 +38,7 @@ class Metarepo
       else
         real_path = File.join(Metarepo::Config.upstream_path, path)
       end
-      case type
+      case upstream_type
       when "yum"
         Dir[File.join(real_path, "*.rpm")]
       when "apt"

--- a/lib/metarepo/upstream.rb
+++ b/lib/metarepo/upstream.rb
@@ -2,13 +2,13 @@
 # Author: adam@opscode.com
 #
 # Copyright 2012, Opscode, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,7 @@ class Metarepo
 
     def list_packages
       if path =~ /^\//
-        real_path = path 
+        real_path = path
       else
         real_path = File.join(Metarepo::Config.upstream_path, path)
       end
@@ -42,26 +42,26 @@ class Metarepo
       when "yum"
         Dir[File.join(real_path, "*.rpm")]
       when "apt"
-				file_list = Array.new
-				Zlib::GzipReader.open(File.join(real_path, "Packages.gz")) do |file|
-					file.each_line do |line|
-						if line =~ /^Filename: (.+)$/
-							file_list << File.expand_path(File.join(
-								real_path,
-								"..",
-								"..",
-								"..",
-								"..",
-								$1
-						  ))
-						end
-					end
-				end
-				file_list
+        file_list = Array.new
+        Zlib::GzipReader.open(File.join(real_path, "Packages.gz")) do |file|
+          file.each_line do |line|
+            if line =~ /^Filename: (.+)$/
+              file_list << File.expand_path(File.join(
+                                                      real_path,
+                                                      "..",
+                                                      "..",
+                                                      "..",
+                                                      "..",
+                                                      $1
+                                                      ))
+            end
+          end
+        end
+        file_list
       when "dir"
         [
-          Dir[File.join(real_path, "*.rpm")],
-          Dir[File.join(real_path, "*.deb")]
+         Dir[File.join(real_path, "*.rpm")],
+         Dir[File.join(real_path, "*.deb")]
         ].flatten
       end
     end
@@ -77,7 +77,7 @@ class Metarepo
         seen_list << package.shasum
         db.transaction do
           package.save
-          add_package(package) unless packages.detect { |o| o.shasum == package.shasum } 
+          add_package(package) unless packages.detect { |o| o.shasum == package.shasum }
         end
       end
 
@@ -85,7 +85,7 @@ class Metarepo
       packages(true).detect do |pkg|
         if !seen_list.include?(pkg.shasum)
           Metarepo::Log.debug("Removing package #{pkg.name} from upstream #{name}")
-          remove_package(pkg) 
+          remove_package(pkg)
         end
       end
     end

--- a/migrations/001_create_upstreams.rb
+++ b/migrations/001_create_upstreams.rb
@@ -21,7 +21,7 @@ Sequel.migration do
       primary_key :id
       String :name, :unique => true 
       String :path
-      String :type
+      String :upstream_type
     end
   end
 

--- a/migrations/002_create_packages.rb
+++ b/migrations/002_create_packages.rb
@@ -27,7 +27,7 @@ Sequel.migration do
       String :maintainer
       String :url
       String :description
-      String :type
+      String :package_type
       String :filename
       String :path
     end

--- a/migrations/004_create_repos.rb
+++ b/migrations/004_create_repos.rb
@@ -21,7 +21,7 @@ Sequel.migration do
       primary_key :id
       String :name, :unique => true 
       String :path
-      String :type
+      String :repo_type
     end
   end
 


### PR DESCRIPTION
I _believe_ this is related to Object#type in Ruby 1.8.7 behaving differently to 1.9.x (?)

Anyway, the intention here was to stop using the ambiguous #type method and rather have sensible, prefixed methods reflecting their actual usage.

I've tested this and Metarepo actually works now :+1: 

```
2012-11-13_04:27:19.11492 [2012-11-13 15:27:19] INFO  WEBrick::HTTPServer#start: pid=22127 port=6667
2012-11-13_04:27:48.76635 localhost - - [13/Nov/2012:15:27:48 EST] "PUT /upstream/test HTTP/1.1" 201 148
2012-11-13_04:27:48.76677 - -> /upstream/test
2012-11-13_04:27:48.77167 localhost - - [13/Nov/2012:15:27:48 EST] "GET /job/Metarepo::Job::UpstreamSyncPackages/694a9642b166a80637f76635f9e9ae7be985cdf9 HTTP/1.1" 200 202
2012-11-13_04:27:48.77205 - -> /job/Metarepo::Job::UpstreamSyncPackages/694a9642b166a80637f76635f9e9ae7be985cdf9
2012-11-13_04:27:50.77813 localhost - - [13/Nov/2012:15:27:50 EST] "GET /job/Metarepo::Job::UpstreamSyncPackages/694a9642b166a80637f76635f9e9ae7be985cdf9 HTTP/1.1" 200 255
2012-11-13_04:27:50.77841 - -> /job/Metarepo::Job::UpstreamSyncPackages/694a9642b166a80637f76635f9e9ae7be985cdf9
```

```
metarepo@ubuntu:~/embedded$ bundle exec bin/metarepo upstream create -n test -p test -t apt
{
  "enqueued_at": "Tue Nov 13 04:27:48 UTC 2012",
  "job_class": "Metarepo::Job::UpstreamSyncPackages",
  "job_id": "694a9642b166a80637f76635f9e9ae7be985cdf9"
}
* Querying job data every 2 seconds *
{
  "enqueued_at": "Tue Nov 13 04:27:48 UTC 2012",
  "job_class": "Metarepo::Job::UpstreamSyncPackages",
  "finished_at": null,
  "job_id": "694a9642b166a80637f76635f9e9ae7be985cdf9",
  "succeeded": null,
  "started_at": null
}
{
  "enqueued_at": "Tue Nov 13 04:27:48 UTC 2012",
  "job_class": "Metarepo::Job::UpstreamSyncPackages",
  "finished_at": "Tue Nov 13 04:27:49 UTC 2012",
  "job_id": "694a9642b166a80637f76635f9e9ae7be985cdf9",
  "succeeded": false,
  "started_at": "Tue Nov 13 04:27:49 UTC 2012"
}
```

Cheers man, much :heart: 
